### PR TITLE
Fix CC dependencies issue + deployment file generation

### DIFF
--- a/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
+++ b/docker-images/kafka/kafka-thirdparty-libs/cc/pom.xml
@@ -2,11 +2,6 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <parent>
-        <groupId>io.strimzi</groupId>
-        <artifactId>strimzi</artifactId>
-        <version>0.16.0-SNAPSHOT</version>
-    </parent>
     <groupId>io.strimzi</groupId>
     <version>1.0.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
@@ -20,6 +15,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <cruise-control.version>2.0.75</cruise-control.version>
+    </properties>
+
     <repositories>
       <repository>
         <id>jcenter</id>
@@ -29,18 +28,8 @@
 
     <dependencies>
         <dependency>
-            <artifactId>scala-library</artifactId>
-            <groupId>org.scala-lang</groupId>
-            <version>2.11.11</version>
-        </dependency>
-        <dependency>
             <groupId>com.linkedin.cruisecontrol</groupId>
             <artifactId>cruise-control</artifactId>
-            <version>${cruise-control.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.linkedin.cruisecontrol</groupId>
-            <artifactId>cruise-control-metrics-reporter</artifactId>
             <version>${cruise-control.version}</version>
         </dependency>
     </dependencies>

--- a/helm-charts/kafka-version-tpl.sh
+++ b/helm-charts/kafka-version-tpl.sh
@@ -14,6 +14,8 @@ do
     kafka_tls_sidecar_version="{{ default .Values.tlsSidecarKafka.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarKafka.image.name }}:{{ default .Values.tlsSidecarKafka.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
     entity_operator_tls_sidecar_version="{{ default .Values.tlsSidecarEntityOperator.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarEntityOperator.image.name }}:{{ default .Values.tlsSidecarEntityOperator.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
     kafka_exporter_version="{{ default .Values.kafkaExporter.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.kafkaExporter.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
+    cruise_control_version="{{ default .Values.cruiseControl.image.repository .Values.imageRepositoryOverride }}/{{ .Values.cruiseControl.image.name }}:{{ default .Values.cruiseControl.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
+    cruise_control_tls_sidecar_version="{{ default .Values.tlsSidecarCruiseControl.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarCruiseControl.image.name }}:{{ default .Values.tlsSidecarCruiseControl.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
     kafka_versions="${kafka_versions}
 ${version}={{ default .Values.kafka.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafka.image.name }}:{{ default .Values.kafka.image.tagPrefix .Values.imageTagOverride }}-kafka-${version}"
     kafka_connect_versions="${kafka_connect_versions}
@@ -50,6 +52,10 @@ cat >"$out" <<EOF
               value: ${zookeeper_tls_sidecar_version}
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
               value: ${kafka_exporter_version}
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: ${cruise_control_version}
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
+              value: ${cruise_control_tls_sidecar_version}
             - name: STRIMZI_KAFKA_IMAGES
               value: | ${kafka_versions}
             - name: STRIMZI_KAFKA_CONNECT_IMAGES

--- a/helm-charts/strimzi-kafka-operator/values.yaml
+++ b/helm-charts/strimzi-kafka-operator/values.yaml
@@ -87,6 +87,16 @@ kafkaExporter:
     repository: strimzi
     name: kafka
     tagPrefix: latest
+cruiseControl:
+  image:
+    repository: strimzi
+    name: kafka
+    tagPrefix: latest
+tlsSidecarCruiseControl:
+  image:
+    repository: strimzi
+    name: kafka
+    tagPrefix: latest
 resources:
   limits:
     memory: 256Mi

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
         <vertx.kafka.client>3.7.1</vertx.kafka.client>
         <okhttp.version>3.12.0</okhttp.version>
         <netty-codec-http.version>4.1.34.Final</netty-codec-http.version>
-        <cruise-control.version>2.0.75</cruise-control.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
So I had the Cruise Control pom.xml inheriting artifact versions and rules from the Strimzi pom.mxl, this was causing maven to pull incorrect dependency versions for CC. The artifact versions declared in the Strimzi pom.xml were prioritized for artifacts common between CC and Strimzi, leading to incorrect versioned artifacts in the CC libs.

Now that the Strimzi pom.xml is not a parent of the CC pom.xml, CC recursively downloads the exact transitive dependency versions it needs. I also found that the cruise-control-metrics-reporter is listed as a dependency of cruise-control so we only need to declare cruise-control as a dependency in the pom.xml file

@tomncooper was also right about the CO deployment file being overridden, there are scripts in the helm-charts/ directory which generate all the `/install/cluster-operator/` files. I have updated these scripts to include the Cruise Control image fields so that they are generated as well