### PR TITLE
Fixed exception when no Cruise Control is deployed

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -133,14 +133,13 @@ public class CruiseControl extends AbstractModel {
     }
 
     public static CruiseControl fromCrd(Kafka kafkaAssembly, KafkaVersion.Lookup versions) {
-        CruiseControl cruiseControl = new CruiseControl(kafkaAssembly.getMetadata().getNamespace(),
-                    kafkaAssembly.getMetadata().getName(),
-                    Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
-
-        KafkaSpec kafkaSpec  = kafkaAssembly.getSpec();
-        CruiseControlSpec spec  = kafkaSpec.getCruiseControl();
+        CruiseControl cruiseControl = null;
+        CruiseControlSpec spec  = kafkaAssembly.getSpec().getCruiseControl();
 
         if (spec != null) {
+            cruiseControl = new CruiseControl(kafkaAssembly.getMetadata().getNamespace(),
+                    kafkaAssembly.getMetadata().getName(),
+                    Labels.fromResource(kafkaAssembly).withKind(kafkaAssembly.getKind()));
             cruiseControl.isDeployed = true;
 
             cruiseControl.setReplicas(spec.getReplicas());
@@ -166,7 +165,7 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setTlsSidecar(tlsSidecar);
 
             cruiseControl = updateConfiguration(spec, cruiseControl);
-            KafkaConfiguration configuration = new KafkaConfiguration(kafkaSpec.getKafka().getConfig().entrySet());
+            KafkaConfiguration configuration = new KafkaConfiguration(kafkaAssembly.getSpec().getKafka().getConfig().entrySet());
             if (configuration.getConfigOption(MIN_INSYNC_REPLICAS) != null) {
                 cruiseControl.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);
             }
@@ -190,8 +189,6 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setTolerations(tolerations(spec));
             cruiseControl.setOwnerReference(kafkaAssembly);
             cruiseControl = updateTemplate(spec, cruiseControl);
-        } else {
-            cruiseControl.isDeployed = false;
         }
 
         return cruiseControl;


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

With the current implementation, when the `Kafka` resource doesn't contain the CC declaration, the CC instance is not `null` and trying to reconcile the related ancillary ConfigMap, a Kubernetes related exception is raised, instead of doing just a noop.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

