### PR TITLE
Fix deployment issues surrounding probes

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -66,16 +66,10 @@ public class CruiseControl extends AbstractModel {
     // Default probe settings (liveness and readiness) for health checks
     protected static final int DEFAULT_HEALTHCHECK_DELAY = 15;
     protected static final int DEFAULT_HEALTHCHECK_TIMEOUT = 5;
-    protected static final int DEFAULT_HEALTHCHECK_SUCCESS = 4;
-    protected static final int DEFAULT_HEALTHCHECK_FAILURE = 10;
-    protected static final int DEFAULT_HEALTHCHECK_PERIOD = 33;
 
     public static final Probe DEFAULT_HEALTHCHECK_OPTIONS = new ProbeBuilder()
             .withInitialDelaySeconds(DEFAULT_HEALTHCHECK_DELAY)
             .withTimeoutSeconds(DEFAULT_HEALTHCHECK_TIMEOUT)
-            .withSuccessThreshold(DEFAULT_HEALTHCHECK_SUCCESS)
-            .withFailureThreshold(DEFAULT_HEALTHCHECK_FAILURE)
-            .withPeriodSeconds(DEFAULT_HEALTHCHECK_PERIOD)
             .build();
 
     private TlsSidecar tlsSidecar;

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -154,14 +154,8 @@ public class CruiseControlTest {
         assertThat(ccContainer.getImage(), is(cc.image));
         assertThat(ccContainer.getLivenessProbe().getInitialDelaySeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_DELAY)));
         assertThat(ccContainer.getLivenessProbe().getTimeoutSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_TIMEOUT)));
-        assertThat(ccContainer.getLivenessProbe().getFailureThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)));
-        assertThat(ccContainer.getLivenessProbe().getSuccessThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)));
-        assertThat(ccContainer.getLivenessProbe().getPeriodSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)));
         assertThat(ccContainer.getReadinessProbe().getInitialDelaySeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_DELAY)));
         assertThat(ccContainer.getReadinessProbe().getTimeoutSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_TIMEOUT)));
-        assertThat(ccContainer.getReadinessProbe().getFailureThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)));
-        assertThat(ccContainer.getReadinessProbe().getSuccessThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)));
-        assertThat(ccContainer.getReadinessProbe().getPeriodSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)));
         assertThat(ccContainer.getEnv(), is(getExpectedEnvVars()));
         assertThat(ccContainer.getPorts().size(), is(1));
         assertThat(ccContainer.getPorts().get(0).getName(), is(CruiseControl.REST_API_PORT_NAME));
@@ -461,16 +455,10 @@ public class CruiseControlTest {
                 .withNewLivenessProbe()
                         .withInitialDelaySeconds(healthDelay)
                         .withTimeoutSeconds(healthTimeout)
-                        .withSuccessThreshold(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)
-                        .withFailureThreshold(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)
-                        .withPeriodSeconds(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)
                 .endLivenessProbe()
                 .withNewReadinessProbe()
                        .withInitialDelaySeconds(healthDelay)
                        .withTimeoutSeconds(healthTimeout)
-                       .withSuccessThreshold(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)
-                       .withFailureThreshold(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)
-                       .withPeriodSeconds(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)
                 .endReadinessProbe()
                 .build();
 
@@ -493,14 +481,8 @@ public class CruiseControlTest {
         assertThat(ccContainer.getImage(), is(cc.image));
         assertThat(ccContainer.getLivenessProbe().getInitialDelaySeconds(), is(new Integer(healthDelay)));
         assertThat(ccContainer.getLivenessProbe().getTimeoutSeconds(), is(new Integer(healthTimeout)));
-        assertThat(ccContainer.getLivenessProbe().getFailureThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)));
-        assertThat(ccContainer.getLivenessProbe().getSuccessThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)));
-        assertThat(ccContainer.getLivenessProbe().getPeriodSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)));
         assertThat(ccContainer.getReadinessProbe().getInitialDelaySeconds(), is(new Integer(healthDelay)));
         assertThat(ccContainer.getReadinessProbe().getTimeoutSeconds(), is(new Integer(healthTimeout)));
-        assertThat(ccContainer.getReadinessProbe().getFailureThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_FAILURE)));
-        assertThat(ccContainer.getReadinessProbe().getSuccessThreshold(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_SUCCESS)));
-        assertThat(ccContainer.getReadinessProbe().getPeriodSeconds(), is(new Integer(CruiseControl.DEFAULT_HEALTHCHECK_PERIOD)));
     }
 
     @AfterAll


### PR DESCRIPTION
Removes some of the custom initialization of probes in CC deployment class, allowing k8s to set sane defaults