### PR TITLE
Clean generation of helm and install files 

### DIFF
--- a/helm-charts/strimzi-kafka-operator/templates/_kafka_image_map.tpl
+++ b/helm-charts/strimzi-kafka-operator/templates/_kafka_image_map.tpl
@@ -13,6 +13,10 @@
               value: {{ default .Values.tlsSidecarZookeeper.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarZookeeper.image.name }}:{{ default .Values.tlsSidecarZookeeper.image.tagPrefix .Values.imageTagOverride }}-kafka-2.4.0
             - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
               value: {{ default .Values.kafkaExporter.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafkaExporter.image.name }}:{{ default .Values.kafkaExporter.image.tagPrefix .Values.imageTagOverride }}-kafka-2.4.0
+            - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+              value: {{ default .Values.cruiseControl.image.repository .Values.imageRepositoryOverride }}/{{ .Values.cruiseControl.image.name }}:{{ default .Values.cruiseControl.image.tagPrefix .Values.imageTagOverride }}-kafka-2.4.0
+            - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
+              value: {{ default .Values.tlsSidecarCruiseControl.image.repository .Values.imageRepositoryOverride }}/{{ .Values.tlsSidecarCruiseControl.image.name }}:{{ default .Values.tlsSidecarCruiseControl.image.tagPrefix .Values.imageTagOverride }}-kafka-2.4.0
             - name: STRIMZI_KAFKA_IMAGES
               value: |                 
                 2.3.1={{ default .Values.kafka.image.repository .Values.imageRepositoryOverride }}/{{ .Values.kafka.image.name }}:{{ default .Values.kafka.image.tagPrefix .Values.imageTagOverride }}-kafka-2.3.1

--- a/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/install/cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -33,8 +33,6 @@ spec:
           value: "300000"
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
           value: strimzi/kafka:latest-kafka-2.4.0
-        - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
-          value: strimzi/kafka:latest-kafka-2.4.0
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
           value: strimzi/kafka:latest-kafka-2.4.0
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
@@ -42,6 +40,8 @@ spec:
         - name: STRIMZI_DEFAULT_KAFKA_EXPORTER_IMAGE
           value: strimzi/kafka:latest-kafka-2.4.0
         - name: STRIMZI_DEFAULT_CRUISE_CONTROL_IMAGE
+          value: strimzi/kafka:latest-kafka-2.4.0
+        - name: STRIMZI_DEFAULT_TLS_SIDECAR_CRUISE_CONTROL_IMAGE
           value: strimzi/kafka:latest-kafka-2.4.0
         - name: STRIMZI_KAFKA_IMAGES
           value: |


### PR DESCRIPTION
Format of files after running ```make all```, current format was manually created