### PR TITLE
Cruise Control Broker Capacity Estimation

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/CruiseControlSpec.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.strimzi.api.kafka.model.balancing.CruiseControlBrokerCapacity;
 import io.strimzi.api.kafka.model.template.CruiseControlTemplate;
 import io.strimzi.crdgenerator.annotations.Description;
 import io.strimzi.crdgenerator.annotations.Maximum;
@@ -28,7 +29,7 @@ import lombok.EqualsAndHashCode;
         "replicas", "image", "config",
         "livenessProbe", "readinessProbe",
         "jvmOptions", "resources",
-        "logging", "tlsSidecar", "template"})
+        "logging", "tlsSidecar", "template", "capacity"})
 @EqualsAndHashCode
 public class CruiseControlSpec implements UnknownPropertyPreserving, Serializable {
     private static final long serialVersionUID = 1L;
@@ -48,6 +49,7 @@ public class CruiseControlSpec implements UnknownPropertyPreserving, Serializabl
     private JvmOptions jvmOptions;
     private Logging logging;
     private CruiseControlTemplate template;
+    private CruiseControlBrokerCapacity capacity;
     private Map<String, Object> config = new HashMap<>(0);
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -81,6 +83,16 @@ public class CruiseControlSpec implements UnknownPropertyPreserving, Serializabl
 
     public void setTlsSidecar(TlsSidecar tlsSidecar) {
         this.tlsSidecar = tlsSidecar;
+    }
+
+    @Description("The Cruise Control broker capacity config.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public CruiseControlBrokerCapacity getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(CruiseControlBrokerCapacity capacity) {
+        this.capacity = capacity;
     }
 
     @Description("The Cruise Control config. Properties with the following prefixes cannot be set: " + FORBIDDEN_PREFIXES)

--- a/api/src/main/java/io/strimzi/api/kafka/model/balancing/CruiseControlBrokerCapacity.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/balancing/CruiseControlBrokerCapacity.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.api.kafka.model.balancing;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.strimzi.api.kafka.model.UnknownPropertyPreserving;
+import io.strimzi.crdgenerator.annotations.Description;
+import io.strimzi.crdgenerator.annotations.Maximum;
+import io.strimzi.crdgenerator.annotations.Minimum;
+import io.sundr.builder.annotations.Buildable;
+import lombok.EqualsAndHashCode;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Representation of the Cruise Control broker capacity settings. Since the Kafka brokers
+ * in Strimzi are homogeneous, the capacity values for each resource will be
+ * used for every broker.
+ */
+@Buildable(
+        editableEnabled = false,
+        generateBuilderPackage = false,
+        builderPackage = "io.fabric8.kubernetes.api.builder"
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"disk", "cpu", "networkIn", "networkOut"})
+@EqualsAndHashCode
+public class CruiseControlBrokerCapacity implements UnknownPropertyPreserving, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer disk;
+    private Integer cpu;
+    private Integer networkIn;
+    private Integer networkOut;
+    private Map<String, Object> additionalProperties = new HashMap<>(0);
+
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    @Description("Broker capacity for disk in megabytes.")
+    public Integer getDisk() {
+        return disk;
+    }
+
+    public void setDisk(Integer disk) {
+        this.disk = disk;
+    }
+
+    @Minimum(0)
+    @Maximum(100)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("Broker capacity for CPU utilization as a percentage (0 - 100).")
+    public Integer getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(Integer cpu) {
+        this.cpu = cpu;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("Broker capacity for network inbound throughput in kilobytes per second.")
+    public Integer getNetworkIn() {
+        return networkIn;
+    }
+
+    public void setNetworkIn(Integer networkIn) {
+        this.networkIn = networkIn;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Description("Broker capacity for network outbound throughput in kilobytes per second.")
+    public Integer getNetworkOut() {
+        return networkOut;
+    }
+
+    public void setNetworkOut(Integer networkOut) {
+        this.networkOut = networkOut;
+    }
+
+    @Override
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @Override
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -189,8 +189,8 @@ public class CruiseControl extends AbstractModel {
             Capacity capacity = new Capacity(kafkaAssembly.getSpec());
             cruiseControl.brokerDiskCapacity = capacity.getDisk();
             cruiseControl.brokerCpuCapacity = capacity.getCpu();
-            cruiseControl.brokerNetworkInCapacity = capacity.getNwIn();
-            cruiseControl.brokerNetworkOutCapacity = capacity.getNwOut();
+            cruiseControl.brokerNetworkInCapacity = capacity.getNetworkIn();
+            cruiseControl.brokerNetworkOutCapacity = capacity.getNetworkOut();
 
             if (spec.getReadinessProbe() != null) {
                 cruiseControl.setReadinessProbe(spec.getReadinessProbe());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -37,7 +37,9 @@ import io.strimzi.api.kafka.model.ProbeBuilder;
 import io.strimzi.api.kafka.model.TlsSidecar;
 import io.strimzi.api.kafka.model.template.CruiseControlTemplate;
 import io.strimzi.operator.cluster.ClusterOperatorConfig;
+import io.strimzi.operator.cluster.model.cruisecontrol.Capacity;
 import io.strimzi.operator.common.Annotations;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -79,6 +81,11 @@ public class CruiseControl extends AbstractModel {
     private TlsSidecar tlsSidecar;
     private String tlsSidecarImage;
     private String minInsyncReplicas = "1";
+    private int brokerDiskCapacity;
+    private int brokerCpuCapacity;
+    private int brokerNetworkInCapacity;
+    private int brokerNetworkOutCapacity;
+
 
     public static final String REST_API_PORT_NAME = "rest-api";
     public static final int REST_API_PORT = 9090;
@@ -91,6 +98,10 @@ public class CruiseControl extends AbstractModel {
     protected static final String ENV_VAR_ZOOKEEPER_CONNECT = "STRIMZI_ZOOKEEPER_CONNECT";
     protected static final String ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS = "STRIMZI_KAFKA_BOOTSTRAP_SERVERS";
     protected static final String ENV_VAR_MIN_INSYNC_REPLICAS = "MIN_INSYNC_REPLICAS";
+    protected static final String ENV_VAR_BROKER_DISK_CAPACITY = "BROKER_DISK_CAPACITY";
+    protected static final String ENV_VAR_BROKER_CPU_CAPACITY = "BROKER_CPU_CAPACITY";
+    protected static final String ENV_VAR_BROKER_NETWORK_IN_CAPACITY = "BROKER_NETWORK_IN_CAPACITY";
+    protected static final String ENV_VAR_BROKER_NETWORK_OUT_CAPACITY = "BROKER_NETWORK_OUT_CAPACITY";
 
 
     // Templates
@@ -168,10 +179,18 @@ public class CruiseControl extends AbstractModel {
             cruiseControl.setTlsSidecar(tlsSidecar);
 
             cruiseControl = updateConfiguration(spec, cruiseControl);
-            KafkaConfiguration configuration = new KafkaConfiguration(kafkaAssembly.getSpec().getKafka().getConfig().entrySet());
+
+            KafkaClusterSpec kafkaClusterSpec = kafkaAssembly.getSpec().getKafka();
+            KafkaConfiguration configuration = new KafkaConfiguration(kafkaClusterSpec.getConfig().entrySet());
             if (configuration.getConfigOption(MIN_INSYNC_REPLICAS) != null) {
                 cruiseControl.minInsyncReplicas = configuration.getConfigOption(MIN_INSYNC_REPLICAS);
             }
+
+            Capacity capacity = new Capacity(kafkaAssembly.getSpec());
+            cruiseControl.brokerDiskCapacity = capacity.getDisk();
+            cruiseControl.brokerCpuCapacity = capacity.getCpu();
+            cruiseControl.brokerNetworkInCapacity = capacity.getNwIn();
+            cruiseControl.brokerNetworkOutCapacity = capacity.getNwOut();
 
             if (spec.getReadinessProbe() != null) {
                 cruiseControl.setReadinessProbe(spec.getReadinessProbe());
@@ -380,6 +399,11 @@ public class CruiseControl extends AbstractModel {
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_BOOTSTRAP_SERVERS, String.valueOf(defaultBootstrapServers(cluster))));
         varList.add(buildEnvVar(ENV_VAR_STRIMZI_KAFKA_GC_LOG_ENABLED, String.valueOf(gcLoggingEnabled)));
         varList.add(buildEnvVar(ENV_VAR_MIN_INSYNC_REPLICAS, String.valueOf(minInsyncReplicas)));
+
+        varList.add(buildEnvVar(ENV_VAR_BROKER_DISK_CAPACITY, String.valueOf(brokerDiskCapacity)));
+        varList.add(buildEnvVar(ENV_VAR_BROKER_CPU_CAPACITY, String.valueOf(brokerCpuCapacity)));
+        varList.add(buildEnvVar(ENV_VAR_BROKER_NETWORK_IN_CAPACITY, String.valueOf(brokerNetworkInCapacity)));
+        varList.add(buildEnvVar(ENV_VAR_BROKER_NETWORK_OUT_CAPACITY, String.valueOf(brokerNetworkOutCapacity)));
 
         heapOptions(varList, 1.0, 0L);
         jvmPerformanceOptions(varList);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageUtils.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/StorageUtils.java
@@ -13,6 +13,17 @@ import io.strimzi.api.kafka.model.storage.Storage;
  */
 public class StorageUtils {
     /**
+     * Parse a K8S-style representation of a quantity of memory, such as {@code 512Mi},
+     * into the equivalent number factor of bytes represented as a long.
+     * @param memory The String representation of the quantity of memory.
+     * @param factor The factor which the bytes should be converted to
+     * @return The equivalent number factor of bytes.
+     */
+    public static long parseMemorybyFactor(String memory, String factor) {
+        return parseMemory(memory) / memoryFactor(factor);
+    }
+
+    /**
      * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
      * into the equivalent number of bytes represented as a long.
      *

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -14,7 +14,7 @@ import io.strimzi.api.kafka.model.storage.Storage;
 
 import java.util.List;
 
-import static io.strimzi.operator.cluster.model.StorageUtils.parseMemory;
+import static io.strimzi.operator.cluster.model.StorageUtils.parseMemorybyFactor;
 
 public class Capacity {
     public static final int DEFAULT_BROKER_DISK_CAPACITY   = 100000;  // in MB
@@ -78,11 +78,7 @@ public class Capacity {
      * @return The equivalent number of Megabytes.
      */
     public static Integer getSizeInMb(String size) {
-        long factor = 1_000L;
-        if (size.charAt(size.length() - 1) == 'i') {
-            factor = 1_024L;
-        }
-        return Math.toIntExact(parseMemory(size) / (factor * factor));
+        return Math.toIntExact(parseMemorybyFactor(size, size.charAt(size.length() - 1) == 'i' ? "Mi" : "M"));
     }
 
     public Integer getDisk() {

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -24,23 +24,16 @@ public class Capacity {
 
     private Integer disk;
     private Integer cpu;
-    private Integer nwIn;
-    private Integer nwOut;
+    private Integer networkIn;
+    private Integer networkOut;
 
     public Capacity(KafkaSpec spec) {
         CruiseControlBrokerCapacity bc = spec.getCruiseControl().getCapacity();
 
-        if (bc != null) {
-            this.disk = bc.getDisk() != null ? bc.getDisk() : generateDiskCapacity(spec.getKafka().getStorage());
-            this.cpu = bc.getCpu() != null ? bc.getCpu() : DEFAULT_BROKER_CPU_CAPACITY;
-            this.nwIn = bc.getNetworkIn() != null ? bc.getNetworkIn() : DEFAULT_BROKER_NW_IN_CAPACITY;
-            this.nwOut = bc.getNetworkOut() != null ? bc.getNetworkOut() : DEFAULT_BROKER_NW_OUT_CAPACITY;
-        } else {
-            this.disk = generateDiskCapacity(spec.getKafka().getStorage());
-            this.cpu = DEFAULT_BROKER_CPU_CAPACITY;
-            this.nwIn = DEFAULT_BROKER_NW_IN_CAPACITY;
-            this.nwOut = DEFAULT_BROKER_NW_OUT_CAPACITY;
-        }
+        this.disk = bc != null && bc.getDisk() != null ? bc.getDisk() : generateDiskCapacity(spec.getKafka().getStorage());
+        this.cpu = bc != null && bc.getCpu() != null ? bc.getCpu() : DEFAULT_BROKER_CPU_CAPACITY;
+        this.networkIn = bc != null && bc.getNetworkIn() != null ? bc.getNetworkIn() : DEFAULT_BROKER_NW_IN_CAPACITY;
+        this.networkOut = bc != null && bc.getNetworkOut() != null ? bc.getNetworkOut() : DEFAULT_BROKER_NW_OUT_CAPACITY;
     }
 
     /**
@@ -97,19 +90,19 @@ public class Capacity {
         this.cpu = cpu;
     }
 
-    public Integer getNwIn() {
-        return nwIn;
+    public Integer getNetworkIn() {
+        return networkIn;
     }
 
-    public void setNwIn(Integer nwIn) {
-        this.nwIn = nwIn;
+    public void setNetworkIn(Integer networkIn) {
+        this.networkIn = networkIn;
     }
 
-    public Integer getNwOut() {
-        return nwOut;
+    public Integer getNetworkOut() {
+        return networkOut;
     }
 
-    public void setNwOut(Integer nwOut) {
-        this.nwOut = nwOut;
+    public void setNetworkOut(Integer networkOut) {
+        this.networkOut = networkOut;
     }
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/cruisecontrol/Capacity.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.model.cruisecontrol;
+
+import io.strimzi.api.kafka.model.balancing.CruiseControlBrokerCapacity;
+import io.strimzi.api.kafka.model.KafkaSpec;
+import io.strimzi.api.kafka.model.storage.EphemeralStorage;
+import io.strimzi.api.kafka.model.storage.JbodStorage;
+import io.strimzi.api.kafka.model.storage.PersistentClaimStorage;
+import io.strimzi.api.kafka.model.storage.SingleVolumeStorage;
+import io.strimzi.api.kafka.model.storage.Storage;
+
+import java.util.List;
+
+import static io.strimzi.operator.cluster.model.StorageUtils.parseMemory;
+
+public class Capacity {
+    public static final int DEFAULT_BROKER_DISK_CAPACITY   = 100000;  // in MB
+    public static final int DEFAULT_BROKER_CPU_CAPACITY    = 100;     // as a percentage (0-100)
+    public static final int DEFAULT_BROKER_NW_IN_CAPACITY  = 10000;   // in KB/s
+    public static final int DEFAULT_BROKER_NW_OUT_CAPACITY = 10000;   // in KB/s
+
+    private Integer disk;
+    private Integer cpu;
+    private Integer nwIn;
+    private Integer nwOut;
+
+    public Capacity(KafkaSpec spec) {
+        CruiseControlBrokerCapacity bc = spec.getCruiseControl().getCapacity();
+
+        if (bc != null) {
+            this.disk = bc.getDisk() != null ? bc.getDisk() : generateDiskCapacity(spec.getKafka().getStorage());
+            this.cpu = bc.getCpu() != null ? bc.getCpu() : DEFAULT_BROKER_CPU_CAPACITY;
+            this.nwIn = bc.getNetworkIn() != null ? bc.getNetworkIn() : DEFAULT_BROKER_NW_IN_CAPACITY;
+            this.nwOut = bc.getNetworkOut() != null ? bc.getNetworkOut() : DEFAULT_BROKER_NW_OUT_CAPACITY;
+        } else {
+            this.disk = generateDiskCapacity(spec.getKafka().getStorage());
+            this.cpu = DEFAULT_BROKER_CPU_CAPACITY;
+            this.nwIn = DEFAULT_BROKER_NW_IN_CAPACITY;
+            this.nwOut = DEFAULT_BROKER_NW_OUT_CAPACITY;
+        }
+    }
+
+    /**
+     * Generate disk capacity configuration from the supplied storage configuration
+     *
+     * @param storage Storage configuration for Kafka cluster
+     * @return Disk capacity configuration as a String
+     */
+    public static Integer generateDiskCapacity(Storage storage) {
+        if (storage instanceof PersistentClaimStorage) {
+            return getSizeInMb(((PersistentClaimStorage) storage).getSize());
+        } else if (storage instanceof EphemeralStorage) {
+            if (((EphemeralStorage) storage).getSizeLimit() != null) {
+                return getSizeInMb(((EphemeralStorage) storage).getSizeLimit());
+            } else {
+                return DEFAULT_BROKER_DISK_CAPACITY;
+            }
+        } else if (storage instanceof JbodStorage) {
+            List<SingleVolumeStorage> volumeList = ((JbodStorage) storage).getVolumes();
+            int size = 0;
+            for (SingleVolumeStorage volume : volumeList) {
+                size += generateDiskCapacity(volume);
+            }
+            return size;
+        } else {
+            throw new IllegalStateException("The declared storage '" + storage.getType() + "' is not supported");
+        }
+    }
+
+    /*
+     * Parse a K8S-style representation of a disk size, such as {@code 100Gi},
+     * into the equivalent number of megabytes represented as a Integer.
+     *
+     * @param size The String representation of the volume size.
+     * @return The equivalent number of Megabytes.
+     */
+    public static Integer getSizeInMb(String size) {
+        long factor = 1_000L;
+        if (size.charAt(size.length() - 1) == 'i') {
+            factor = 1_024L;
+        }
+        return Math.toIntExact(parseMemory(size) / (factor * factor));
+    }
+
+    public Integer getDisk() {
+        return disk;
+    }
+
+    public void setDisk(Integer disk) {
+        this.disk = disk;
+    }
+
+    public Integer getCpu() {
+        return cpu;
+    }
+
+    public void setCpu(Integer cpu) {
+        this.cpu = cpu;
+    }
+
+    public Integer getNwIn() {
+        return nwIn;
+    }
+
+    public void setNwIn(Integer nwIn) {
+        this.nwIn = nwIn;
+    }
+
+    public Integer getNwOut() {
+        return nwOut;
+    }
+
+    public void setNwOut(Integer nwOut) {
+        this.nwOut = nwOut;
+    }
+}

--- a/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
+++ b/docker-images/kafka/cruise-control-scripts/cruise_control_config_generator.sh
@@ -4,21 +4,22 @@ CC_CAPACITY_FILE="/tmp/capacity.json"
 CC_CLUSTER_CONFIG_FILE="/tmp/clusterConfig.json"
 
 # Generate capacity file
-# TODO: Update DISK value based on volume sizes
 cat <<EOF > $CC_CAPACITY_FILE
 {
 	"brokerCapacities": [{
 		"brokerId": "-1",
 		"capacity": {
-			"DISK": "100000",
-			"CPU": "100",
-			"NW_IN": "10000",
-			"NW_OUT": "10000"
+			"DISK": "$BROKER_DISK_CAPACITY",
+			"CPU": "$BROKER_CPU_CAPACITY",
+			"NW_IN": "$BROKER_NETWORK_IN_CAPACITY",
+			"NW_OUT": "$BROKER_NETWORK_OUT_CAPACITY"
 		},
 		"doc": "This is the default capacity. Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
 	}]
 }
 EOF
+
+cat $CC_CAPACITY_FILE
 
 # Generate cluster config
 cat <<EOF > $CC_CLUSTER_CONFIG_FILE

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1366,6 +1366,8 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |xref:type-TlsSidecar-{context}[`TlsSidecar`]
 |template        1.2+<.<|Template to specify how Cruise Control resources, `Deployments` and `Pods`, are generated.
 |xref:type-CruiseControlTemplate-{context}[`CruiseControlTemplate`]
+|capacity        1.2+<.<|The Cruise Control broker capacity config.
+|xref:type-CruiseControlBrokerCapacity-{context}[`CruiseControlBrokerCapacity`]
 |====
 
 [id='type-CruiseControlTemplate-{context}']
@@ -1389,6 +1391,25 @@ Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
 |cruiseControlContainer  1.2+<.<|Template for the Cruise Control container.
 |xref:type-ContainerTemplate-{context}[`ContainerTemplate`]
+|====
+
+[id='type-CruiseControlBrokerCapacity-{context}']
+### `CruiseControlBrokerCapacity` schema reference
+
+Used in: xref:type-CruiseControlSpec-{context}[`CruiseControlSpec`]
+
+
+[options="header"]
+|====
+|Property           |Description
+|disk        1.2+<.<|Broker capacity for disk in megabytes.
+|integer
+|cpu         1.2+<.<|Broker capacity for CPU utilization as a percentage (0 - 100).
+|integer
+|networkIn   1.2+<.<|Broker capacity for network inbound throughput in kilobytes per second.
+|integer
+|networkOut  1.2+<.<|Broker capacity for network outbound throughput in kilobytes per second.
+|integer
 |====
 
 [id='type-JmxTransSpec-{context}']

--- a/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
+++ b/documentation/modules/cruise-control/proc-deploying-cruise-control.adoc
@@ -32,7 +32,11 @@ spec:
   # ...
   cruiseControl:
     replicas: 1 <1>
-    config: <2>
+    capacity: <2>
+      networkIn: 10000
+      networkOut: 10000
+      # ...
+    config: <3>
       default.goals: >
          com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal,
          com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal
@@ -40,15 +44,15 @@ spec:
       metadata.max.age.ms: 300000
       send.buffer.bytes: 131072
       # ...
-    resources: <3>
+    resources: <4>
       requests:
         cpu: 200m
         memory: 64Mi
       limits:
         cpu: 500m
         memory: 128Mi
-    logging: debug <4>
-    template: <5>
+    logging: debug <5>
+    template: <6>
       pod:
         metadata:
           labels:
@@ -57,21 +61,22 @@ spec:
           runAsUser: 1000001
           fsGroup: 0
         terminationGracePeriodSeconds: 120
-    readinessProbe: <6>
+    readinessProbe: <7>
       initialDelaySeconds: 15
       timeoutSeconds: 5
-    livenessProbe: <7>
+    livenessProbe: <8>
       initialDelaySeconds: 15
       timeoutSeconds: 5
 # ...
 ----
 <1> Number of Cruise Control application instances; set to `1` to run or `0` to pause the application.
-<2> Specifies the Cruise Control configuration. You can provide any xref:ref-cruise-control-configuration-{context}[standard configuration option] apart from those managed directly by {ProductName}.
-<3> CPU and memory resources reserved for Cruise Control. For more information, see xref:assembly-resource-limits-and-requests-deployment-configuration-kafka[].
-<4> Logging configuration, to log messages with a given severity (debug, info, warn, error, fatal) or above.
-<5> xref:assembly-customizing-deployments-str[Customization of deployment templates and pods].
-<6> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck readiness probes].
-<7> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck liveness probes].
+<2> Specifies the Cruise Control capacity configuration. For more information, see xref:capacity_configuration[capacity configuration].
+<3> Specifies the Cruise Control configuration. You can provide any xref:ref-cruise-control-configuration-{context}[standard configuration option] apart from those managed directly by {ProductName}.
+<4> CPU and memory resources reserved for Cruise Control. For more information, see xref:assembly-resource-limits-and-requests-deployment-configuration-kafka[].
+<5> Logging configuration, to log messages with a given severity (debug, info, warn, error, fatal) or above.
+<6> xref:assembly-customizing-deployments-str[Customization of deployment templates and pods].
+<7> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck readiness probes].
+<8> xref:assembly-healthchecks-deployment-configuration-kafka[Healthcheck liveness probes].
 
 . Create or update the resource:
 +

--- a/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
+++ b/documentation/modules/cruise-control/ref-cruise-control-configuration.adoc
@@ -55,3 +55,38 @@ spec:
       send.buffer.bytes: 131072
     # ...
 ----
+== Capacity configuration
+
+Cruise Control uses capacity limits to determine if goals related to broker resources are being violated.
+
+Capacity limits for broker resources can be specified in the `capacity` property in `Kafka.spec.cruiseControl`.
+Capacity limits can be set for the following broker resources in the described units:
+
+* `disk`  - Disk storage in MB
+* `cpu`   - CPU utilization as a percent (0-100)
+* `networkIn`  - Network inbound throughput in KB/s
+* `networkOut` - Newtork outbound throughput in KB/s
+
+Since {ProductName} brokers are homogenous, Cruise Control will apply the same capacity limits to every broker it is monitoring.
+
+.An example Cruise Control capacity configuration
+[source,yaml,subs="attributes+"]
+----
+apiVersion: {KafkaApiVersion}
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  # ...
+  cruiseControl:
+    # ...
+    capacity:
+      disk: 100000
+      cpu: 100
+      networkIn: 10000
+      networkOut: 10000
+    # ...
+----
+
+.Additional resources
+For information, refer to the xref:type-CruiseControlBrokerCapacity-reference[Capacity schema reference].

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -4468,6 +4468,7 @@ spec:
                 replicas:
                   type: integer
                   minimum: 0
+                  maximum: 1
                   description: The number of pods in the `Deployment`.
                 image:
                   type: string
@@ -5099,6 +5100,27 @@ spec:
                       description: Template for the Cruise Control container.
                   description: Template to specify how Cruise Control resources, `Deployments`
                     and `Pods`, are generated.
+                capacity:
+                  type: object
+                  properties:
+                    disk:
+                      type: integer
+                      description: Broker capacity for disk in megabytes.
+                    cpu:
+                      type: integer
+                      minimum: 0
+                      maximum: 100
+                      description: Broker capacity for CPU utilization as a percentage
+                        (0 - 100).
+                    networkIn:
+                      type: integer
+                      description: Broker capacity for network inbound throughput
+                        in kilobytes per second.
+                    networkOut:
+                      type: integer
+                      description: Broker capacity for network outbound throughput
+                        in kilobytes per second.
+                  description: The Cruise Control broker capacity config.
               required:
               - replicas
               description: Configuration of Cruise Control.


### PR DESCRIPTION
This PR allows users to configure the default broker settings of the Cruise Control capacity file [1]. 

Cruise Control uses these capacity limits to determine if goals related to broker resources are being violated. (e.g. DiskCapacityGoal: violated when the disk capacity set for a broker is exceeded by the disk being used by that broker).

This API only allows users to alter the default broker settings since the the Strimzi brokers pods are homogeneous and should have identical resources available. When capacity settings are not provided by the user and not generated by Strimzi, the defaults from the Cruise Control project are used [1]

```
apiVersion: kafka.strimzi.io/v1beta1
kind: Kafka
metadata:
...
spec:
  kafka:
    ...
  cruiseControl:
    capacity:
      disk: 100000  # in MB
      cpu: 100      # as a percentage (0-100)
      nwIn: 10000   # KB/s
      nwOut: 10000  # KB/s
      ...
```

[1] https://github.com/linkedin/cruise-control/blob/2.0.97/config/capacity.json