### PR TITLE
Fixed NPE on updating status when exception

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
@@ -158,11 +158,11 @@ public class KafkaClusterRebalanceAssemblyOperator
                                                     KafkaClusterRebalanceStatus desiredStatus,
                                                     CrdOperator<KubernetesClient, KafkaClusterRebalance, KafkaClusterRebalanceList, DoneableKafkaClusterRebalance> clusterRebalanceOperations,
                                                     Throwable e) {
-        String type = desiredStatus.getConditions().get(0).getType();
         if (e != null) {
             StatusUtils.setStatusConditionAndObservedGeneration(clusterRebalance, desiredStatus, e);
-        } else if (type != null) {
-            StatusUtils.setStatusConditionAndObservedGeneration(clusterRebalance, desiredStatus, type);
+        } else if (desiredStatus.getConditions() != null && desiredStatus.getConditions().get(0).getType() != null) {
+            StatusUtils.setStatusConditionAndObservedGeneration(clusterRebalance, desiredStatus,
+                    desiredStatus.getConditions().get(0).getType());
         } else {
             throw new IllegalArgumentException("Status related exception and type cannot be both null");
         }


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Bugfix

### Description

This fixes an NPE when the rebalance resource status is updated in case of exception.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

