### PR TITLE
Fixed annotation and CC REST API port

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
@@ -19,6 +19,7 @@ import io.strimzi.api.kafka.model.KafkaClusterRebalanceBuilder;
 import io.strimzi.api.kafka.model.status.KafkaClusterRebalanceStatus;
 import io.strimzi.api.kafka.model.status.KafkaClusterRebalanceStatusBuilder;
 import io.strimzi.operator.PlatformFeaturesAvailability;
+import io.strimzi.operator.cluster.model.CruiseControl;
 import io.strimzi.operator.cluster.model.InvalidResourceException;
 import io.strimzi.operator.cluster.model.NoSuchResourceException;
 import io.strimzi.operator.cluster.model.StatusDiff;
@@ -374,7 +375,7 @@ public class KafkaClusterRebalanceAssemblyOperator
                             if (getRebalanceAnnotation(freshClusterRebalance) == RebalanceAnnotation.stop) {
                                 log.debug("{}: Stopping current Cruise Control rebalance user task", reconciliation);
                                 vertx.cancelTimer(t);
-                                apiClient.stopExecution(host, 9090 /* TODO: need public constant from CruiseControl model */).setHandler(stopResult -> {
+                                apiClient.stopExecution(host, CruiseControl.REST_API_PORT).setHandler(stopResult -> {
                                     if (stopResult.succeeded()) {
                                         p.complete(new KafkaClusterRebalanceStatusBuilder()
                                                 .withSessionId(null)
@@ -386,7 +387,7 @@ public class KafkaClusterRebalanceAssemblyOperator
                                 });
                             } else {
                                 log.debug("{}: Getting Cruise Control rebalance user task status", reconciliation);
-                                apiClient.getUserTaskStatus(host, 9090 /* TODO: need public constant from CruiseControl model */, sessionId).setHandler(userTaskResult -> {
+                                apiClient.getUserTaskStatus(host, CruiseControl.REST_API_PORT, sessionId).setHandler(userTaskResult -> {
                                     if (userTaskResult.succeeded()) {
                                         CruiseControlResponse response = userTaskResult.result();
                                         JsonObject taskStatusJson = response.getJson();
@@ -503,7 +504,7 @@ public class KafkaClusterRebalanceAssemblyOperator
                             if (getRebalanceAnnotation(freshClusterRebalance) == RebalanceAnnotation.stop) {
                                 log.debug("{}: Stopping current Cruise Control rebalance user task", reconciliation);
                                 vertx.cancelTimer(t);
-                                apiClient.stopExecution(host, 9090 /* TODO: need public constant from CruiseControl model */).setHandler(stopResult -> {
+                                apiClient.stopExecution(host, CruiseControl.REST_API_PORT).setHandler(stopResult -> {
                                     if (stopResult.succeeded()) {
                                         p.complete(new KafkaClusterRebalanceStatusBuilder()
                                                 .withSessionId(null)
@@ -515,7 +516,7 @@ public class KafkaClusterRebalanceAssemblyOperator
                                 });
                             } else {
                                 log.info("{}: Getting Cruise Control rebalance user task status", reconciliation);
-                                apiClient.getUserTaskStatus(host, 9090 /* TODO: need public constant from CruiseControl model */, sessionId).setHandler(userTaskResult -> {
+                                apiClient.getUserTaskStatus(host, CruiseControl.REST_API_PORT, sessionId).setHandler(userTaskResult -> {
                                     if (userTaskResult.succeeded()) {
                                         CruiseControlResponse response = userTaskResult.result();
                                         JsonObject taskStatusJson = response.getJson();
@@ -622,7 +623,7 @@ public class KafkaClusterRebalanceAssemblyOperator
         }
         State ready = dryrun ? State.ProposalReady : State.Ready;
         State inprogress = dryrun ? State.PendingProposal : State.Rebalancing;
-        return apiClient.rebalance(host, 9090 /* TODO: need public constant from CruiseControl model */, rebalanceOptionsBuilder.build())
+        return apiClient.rebalance(host, CruiseControl.REST_API_PORT, rebalanceOptionsBuilder.build())
                 .map(response -> {
                     if (response.getJson() != null) {
                         return new KafkaClusterRebalanceStatusBuilder()

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
@@ -52,7 +52,7 @@ public class KafkaClusterRebalanceAssemblyOperator
 
     private static final Logger log = LogManager.getLogger(KafkaClusterRebalanceAssemblyOperator.class.getName());
 
-    public static final String ANNO_STRIMZI_IO_REBALANCE = Annotations.STRIMZI_DOMAIN + "/rebalance";
+    public static final String ANNO_STRIMZI_IO_REBALANCE = Annotations.STRIMZI_DOMAIN + "rebalance";
     private static final long REBALANCE_TASK_STATUS_TIMER_MS = 5_000;
 
     private final CrdOperator<KubernetesClient, KafkaClusterRebalance, KafkaClusterRebalanceList, DoneableKafkaClusterRebalance> clusterRebalanceOperator;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After rebasing from latest Strimzi, it seems the annotation prefix is changed. This PR fixes the related "rebalance" annotation built.
It also uses the Cruise Control REST API port constant instead of the hardcoded one.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

