### PR TITLE
Added rights on kafkaclusterrebalances in cluster role and strimzi

### DIFF
--- a/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/cluster-operator/src/main/resources/cluster-roles/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -61,6 +61,9 @@ rules:
   # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access KafkaMirrorMaker2 resources
   - kafkamirrormaker2s
   - kafkamirrormaker2s/status
+  # The cluster operator runs the KafkaClusterRebalanceAssemblyOperator, which needs to access KafkaClusterRebalance resources
+  - kafkaclusterrebalances
+  - kafkaclusterrebalances/status
   verbs:
   - get
   - list

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -1352,7 +1352,7 @@ Used in: xref:type-KafkaSpec-{context}[`KafkaSpec`]
 |Property               |Description
 |image           1.2+<.<|The docker image for the pods.
 |string
-|config          1.2+<.<|The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., ssl.
+|config          1.2+<.<|The Cruise Control configuration. For a full list of configuration options refer to https://github.com/linkedin/cruise-control/wiki/Configurations. Note that properties with the following prefixes cannot be set: bootstrap.servers, client.id, zookeeper., network., security., failed.brokers.zk.path,webserver.http., webserver.api.urlprefix, webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers, metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file, self.healing., anomaly.detection., ssl.
 |map
 |livenessProbe   1.2+<.<|Pod liveness checking for the Cruise Control container.
 |xref:type-Probe-{context}[`Probe`]

--- a/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -66,6 +66,9 @@ rules:
     # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access KafkaMirrorMaker2 resources
   - kafkamirrormaker2s
   - kafkamirrormaker2s/status
+    # The cluster operator runs the KafkaClusterRebalanceAssemblyOperator, which needs to access KafkaClusterRebalance resources
+  - kafkaclusterrebalances
+  - kafkaclusterrebalances/status
   verbs:
   - get
   - list

--- a/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
+++ b/install/cluster-operator/020-ClusterRole-strimzi-cluster-operator-role.yaml
@@ -61,6 +61,9 @@ rules:
   # The cluster operator runs the KafkaMirrorMaker2AssemblyOperator, which needs to access KafkaMirrorMaker2 resources
   - kafkamirrormaker2s
   - kafkamirrormaker2s/status
+  # The cluster operator runs the KafkaClusterRebalanceAssemblyOperator, which needs to access KafkaClusterRebalance resources
+  - kafkaclusterrebalances
+  - kafkaclusterrebalances/status
   verbs:
   - get
   - list

--- a/install/cluster-operator/040-Crd-kafka.yaml
+++ b/install/cluster-operator/040-Crd-kafka.yaml
@@ -4856,7 +4856,7 @@ spec:
                     failed.brokers.zk.path,webserver.http., webserver.api.urlprefix,
                     webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers,
                     metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file,
-                    self.healing., ssl.'
+                    self.healing., anomaly.detection., ssl.'
                 livenessProbe:
                   type: object
                   properties:

--- a/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
+++ b/install/strimzi-admin/010-ClusterRole-strimzi-admin.yaml
@@ -20,6 +20,7 @@ rules:
   - kafkabridges
   - kafkaconnectors
   - kafkamirrormaker2s
+  - kafkaclusterrebalances
   verbs:
   - get
   - list

--- a/install/strimzi-admin/020-ClusterRole-strimzi-view.yaml
+++ b/install/strimzi-admin/020-ClusterRole-strimzi-view.yaml
@@ -19,6 +19,7 @@ rules:
   - kafkabridges
   - kafkaconnectors
   - kafkamirrormaker2s
+  - kafkaclusterrebalances
   verbs:
   - get
   - list


### PR DESCRIPTION
admin/view

Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

This PR adds the rights for handling `kafkaclusterrebalances` from the service account.
This PR also adds some missing not updated CRDs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

