### PR TITLE
Fixed state machine based on cruise control API responses

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
@@ -11,7 +11,10 @@ import io.vertx.core.Future;
  */
 public interface CruiseControlApi {
 
-    String USER_ID_HEADER = "User-Task-ID";
+    String CC_REST_API_ERROR_KEY = "errorMessage";
+    String CC_REST_API_STACKTRACE_KEY = "stackTrace";
+    String CC_REST_API_USER_ID_HEADER = "User-Task-ID";
+    String CC_REST_API_SUMMARY = "summary";
 
     Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose);
     Future<Boolean> isProposalReady(String host, int port);

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApiImpl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApiImpl.java
@@ -9,6 +9,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 
 public class CruiseControlApiImpl implements CruiseControlApi {
@@ -42,7 +43,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .get(port, host, path, response -> {
                     response.exceptionHandler(result::fail);
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        String userTaskID = response.getHeader(USER_ID_HEADER);
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
                         response.bodyHandler(buffer -> {
                             JsonObject json = buffer.toJsonObject();
                             if (json.containsKey(CC_REST_API_ERROR_KEY)) {
@@ -62,7 +63,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .exceptionHandler(result::fail);
 
         if (userTaskId != null) {
-            request.putHeader(USER_ID_HEADER, userTaskId);
+            request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
         }
 
         request.end();
@@ -113,19 +114,26 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                     response.exceptionHandler(result::fail);
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
                         response.bodyHandler(buffer -> {
-                            String returnedUTID = response.getHeader(USER_ID_HEADER);
+                            String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
                             JsonObject json = buffer.toJsonObject();
-                            boolean notEnoughData = false;
+                            CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
+                            result.complete(ccResponse);
+                        });
+                    } else if (response.statusCode() == 500) {
+                        response.bodyHandler(buffer -> {
+                            String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
+                            JsonObject json = buffer.toJsonObject();
+                            CruiseControlResponse ccResponse = new CruiseControlResponse(userTaskID, json);
                             if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                 if (json.getString(CC_REST_API_ERROR_KEY).contains("NotEnoughValidWindowsException")) {
-                                    notEnoughData = true;
+                                    ccResponse.setNotEnoughDataForProposal(true);
+                                    result.complete(ccResponse);
                                 } else {
                                     result.fail(json.getString(CC_REST_API_ERROR_KEY));
                                 }
+                            } else {
+                                result.complete(ccResponse);
                             }
-                            CruiseControlResponse ccResponse = new CruiseControlResponse(returnedUTID, json);
-                            ccResponse.setNotEnoughDataForProposal(notEnoughData);
-                            result.complete(ccResponse);
                         });
                     } else {
                         result.fail(new CruiseControlRestException(
@@ -136,7 +144,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .exceptionHandler(result::fail);
 
         if (userTaskId != null) {
-            request.putHeader(USER_ID_HEADER, userTaskId);
+            request.putHeader(CC_REST_API_USER_ID_HEADER, userTaskId);
         }
 
         request.end();
@@ -161,9 +169,12 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .get(port, host, path, response -> {
                     response.exceptionHandler(result::fail);
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        String userTaskID = response.getHeader(USER_ID_HEADER);
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
                         response.bodyHandler(buffer -> {
-                            JsonObject json = buffer.toJsonObject();
+                            JsonObject jsonUserTask = buffer.toJsonObject().getJsonArray("userTasks").getJsonObject(0);
+                            JsonObject json = new JsonObject()
+                                    .put("Status", jsonUserTask.getString("Status"))
+                                    .put("summary", ((JsonObject) Json.decodeValue(jsonUserTask.getString("originalResponse"))).getJsonObject("summary"));
                             if (json.containsKey(CC_REST_API_ERROR_KEY)) {
                                 result.fail(json.getString(CC_REST_API_ERROR_KEY));
                             } else {
@@ -197,7 +208,7 @@ public class CruiseControlApiImpl implements CruiseControlApi {
                 .post(port, host, path, response -> {
                     response.exceptionHandler(result::fail);
                     if (response.statusCode() == 200 || response.statusCode() == 201) {
-                        String userTaskID = response.getHeader(USER_ID_HEADER);
+                        String userTaskID = response.getHeader(CC_REST_API_USER_ID_HEADER);
                         response.bodyHandler(buffer -> {
                             JsonObject json = buffer.toJsonObject();
                             if (json.containsKey(CC_REST_API_ERROR_KEY)) {

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControl.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControl.java
@@ -44,8 +44,8 @@ public class MockCruiseControl {
     public static final String USER_TASK_REBALANCE_NO_GOALS_VERBOSE_UTID = USER_TASK_REBALANCE_NO_GOALS + SEP + VERBOSE;
     public static final String USER_TASK_REBALANCE_NO_GOALS_RESPONSE_UTID = USER_TASK_REBALANCE_NO_GOALS + SEP + RESPONSE;
     public static final String USER_TASK_REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID = USER_TASK_REBALANCE_NO_GOALS_VERBOSE_UTID + SEP + RESPONSE;
-    public static final String REBALANCE_ERROR = REBALANCE + SEP + "error";
-    public static final String REBALANCE_ERROR_RESPONSE_UTID = REBALANCE_ERROR + SEP + RESPONSE;
+    public static final String REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR = REBALANCE + SEP + "error";
+    public static final String REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR_RESPONSE_UTID = REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR + SEP + RESPONSE;
     public static final String STATE_PROPOSAL_NOT_READY = STATE + SEP + "proposal" + SEP + "not" + SEP + "ready";
     public static final String STATE_PROPOSAL_NOT_READY_RESPONSE = STATE_PROPOSAL_NOT_READY + SEP + RESPONSE;
 
@@ -97,7 +97,7 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.JSON.key, "true|false"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withPath(CruiseControlEndpoints.STATE.path)
-                                .withHeaders(header(CruiseControlApi.USER_ID_HEADER, STATE_PROPOSAL_NOT_READY)))
+                                .withHeaders(header(CruiseControlApi.CC_REST_API_USER_ID_HEADER, STATE_PROPOSAL_NOT_READY)))
                 .respond(
                         response()
                                 .withBody(jsonProposalNotReady)
@@ -152,12 +152,13 @@ public class MockCruiseControl {
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.DRY_RUN.key, "true|false"))
                                 .withQueryStringParameter(Parameter.param(CruiseControlParameters.VERBOSE.key, "true|false"))
                                 .withPath(CruiseControlEndpoints.REBALANCE.path)
-                                .withHeaders(header(CruiseControlApi.USER_ID_HEADER, REBALANCE_ERROR)))
+                                .withHeaders(header(CruiseControlApi.CC_REST_API_USER_ID_HEADER, REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR)))
 
                 .respond(
                         response()
+                                .withStatusCode(500)
                                 .withBody(jsonError)
-                                .withHeaders(header(CruiseControlApi.USER_ID_HEADER, REBALANCE_ERROR_RESPONSE_UTID))
+                                .withHeaders(header(CruiseControlApi.CC_REST_API_USER_ID_HEADER, REBALANCE_NOT_ENOUGH_VALID_WINDOWS_ERROR_RESPONSE_UTID))
                                 .withDelay(TimeUnit.SECONDS, RESPONSE_DELAY_SEC));
 
         // Rebalance response with no goals set - non-verbose

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControlTest.java
@@ -57,7 +57,7 @@ public class MockCruiseControlTest {
             for (int i = 1; i <= pendingCalls; i++) {
                 statusFuture = statusFuture.compose(response -> {
                     context.verify(() -> assertThat(
-                            response.getJson().getJsonArray("userTasks").getJsonObject(0).getString("Status"),
+                            response.getJson().getString("Status"),
                             is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                     );
                     return client.getUserTaskStatus(HOST, PORT, userTaskID);
@@ -67,7 +67,7 @@ public class MockCruiseControlTest {
 
         statusFuture.compose(response -> {
             context.verify(() -> assertThat(
-                    response.getJson().getJsonArray("userTasks").getJsonObject(0).getString("Status"),
+                    response.getJson().getString("Status"),
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()))
             );
             return Future.succeededFuture(response);
@@ -114,7 +114,7 @@ public class MockCruiseControlTest {
         for (int i = 1; i <= pendingCalls1; i++) {
             statusFuture = statusFuture.compose(response -> {
                 context.verify(() -> assertThat(
-                        response.getJson().getJsonArray("userTasks").getJsonObject(0).getString("Status"),
+                        response.getJson().getString("Status"),
                         is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
                 firstPending.flag();
@@ -124,7 +124,7 @@ public class MockCruiseControlTest {
 
         statusFuture = statusFuture.compose(response -> {
             context.verify(() -> assertThat(
-                    response.getJson().getJsonArray("userTasks").getJsonObject(0).getString("Status"),
+                    response.getJson().getString("Status"),
                     is(CruiseControlUserTaskStatus.COMPLETED.toString()))
             );
             return Future.succeededFuture(response);
@@ -147,7 +147,7 @@ public class MockCruiseControlTest {
         for (int i = 1; i <= pendingCalls2; i++) {
             statusFuture = statusFuture.compose(response -> {
                 context.verify(() -> assertThat(
-                        response.getJson().getJsonArray("userTasks").getJsonObject(0).getString("Status"),
+                        response.getJson().getString("Status"),
                         is(CruiseControlUserTaskStatus.IN_EXECUTION.toString()))
                 );
                 secondPending.flag();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR fixes Kafka rebalance operator state machine based on different responses from the cruise control API.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

