### PR TITLE
Fixed NotReady state Javadoc

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
@@ -240,7 +240,10 @@ public class KafkaClusterRebalanceAssemblyOperator
         Stopped,
         /**
          * There's been some error.
-         * There is no transition from this state to a new one.
+         * Transitions to:
+         * <dl>
+         *     <dt>New</dt><dd>If the error was caused by the resource itself that was fixed by the user.</dd>
+         * </dl>
          */
         NotReady,
         /**


### PR DESCRIPTION
Signed-off-by: Paolo Patierno <ppatierno@live.com>

### Type of change

- Documentation

### Description

Trivial PR to fix `NotReady` state doc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

