### PR TITLE
Added skip hard goal check flag in the rebalance resource

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -23,13 +23,14 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "goals", "verbose" })
+@JsonPropertyOrder({ "goals", "skipHardGoalCheck", "verbose" })
 @EqualsAndHashCode
 public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Serializable {
 
     private static final long serialVersionUID = 1L;
 
     private List<String> goals;
+    private boolean skipHardGoalCheck;
     private boolean verbose = false;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
@@ -43,6 +44,16 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     public void setGoals(List<String> goals) {
         this.goals = goals;
+    }
+
+    @Description("Whether allow hard goals be skipped in proposal generation. Default is false.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public boolean isSkipHardGoalCheck() {
+        return skipHardGoalCheck;
+    }
+
+    public void setSkipHardGoalCheck(boolean skipHardGoalCheck) {
+        this.skipHardGoalCheck = skipHardGoalCheck;
     }
 
     @Description("Enable the verbose mode for the JSON string describing the optimization result in the related status")

--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -35,9 +35,9 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
-    @Description("A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it." +
+    @Description("A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal." +
             "The supported goals are available at https://github.com/linkedin/cruise-control#goals." +
-            "Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.")
+            "If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.")
     public List<String> getGoals() {
         return goals;
     }
@@ -46,7 +46,7 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
         this.goals = goals;
     }
 
-    @Description("Whether allow hard goals be skipped in proposal generation. Default is false.")
+    @Description("Whether to allow hard goals to be skipped in rebalance proposal generation. Default is false.")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public boolean isSkipHardGoalCheck() {
         return skipHardGoalCheck;

--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
@@ -34,6 +34,11 @@ public class KafkaClusterRebalanceCrdIT extends AbstractCrdIT {
         createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals-verbose.yaml");
     }
 
+    @Test
+    void testKafkaClusterRebalanceWithGoalsSkipHardGoalCheck() {
+        createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals-skip-hard-goal-check.yaml");
+    }
+
     @BeforeAll
     void setupEnvironment() {
         cluster.createNamespace(NAMESPACE);

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-skip-hard-goal-check.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-skip-hard-goal-check.yaml
@@ -1,0 +1,9 @@
+apiVersion: kafka.strimzi.io/v1alpha1
+kind: KafkaClusterRebalance
+metadata:
+  name: my-rebalance
+spec:
+  goals:
+    - DiskCapacityGoal
+    - CpuCapacityGoal
+  skipHardGoalCheck: true

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaClusterRebalanceAssemblyOperator.java
@@ -285,6 +285,9 @@ public class KafkaClusterRebalanceAssemblyOperator
         if (clusterRebalance.getSpec().getGoals() != null) {
             rebalanceOptionsBuilder.withGoals(clusterRebalance.getSpec().getGoals());
         }
+        if (clusterRebalance.getSpec().isSkipHardGoalCheck()) {
+            rebalanceOptionsBuilder.withSkipHardGoalCheck();
+        }
         log.info("{}: Rebalance action from state [{}]", reconciliation, currentState);
 
         return computeNextStatus(reconciliation, host, apiClient, clusterRebalance, currentState, rebalanceAnnotation, rebalanceOptionsBuilder)

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlParameters.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlParameters.java
@@ -10,6 +10,7 @@ public enum CruiseControlParameters {
     JSON("json"),
     GOALS("goals"),
     VERBOSE("verbose"),
+    SKIP_HARD_GOAL_CHECK("skip_hard_goal_check"),
     FETCH_COMPLETE("fetch_completed_task"),
     USER_TASK_IDS("user_task_ids");
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/PathBuilder.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/PathBuilder.java
@@ -49,7 +49,8 @@ public class PathBuilder {
     public PathBuilder addRebalanceParameters(RebalanceOptions options) {
         if (options != null) {
             PathBuilder builder = addParameter(CruiseControlParameters.DRY_RUN, String.valueOf(options.isDryRun()))
-                    .addParameter(CruiseControlParameters.VERBOSE, String.valueOf(options.isVerbose()));
+                    .addParameter(CruiseControlParameters.VERBOSE, String.valueOf(options.isVerbose()))
+                    .addParameter(CruiseControlParameters.SKIP_HARD_GOAL_CHECK, String.valueOf(options.isSkipHardGoalCheck()));
 
             if (options.getGoals() != null) {
                 builder.addParameter(CruiseControlParameters.GOALS, options.getGoals());

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/RebalanceOptions.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/RebalanceOptions.java
@@ -11,6 +11,7 @@ public class RebalanceOptions {
     private boolean isDryRun;
     private List<String> goals;
     private boolean verbose;
+    private boolean skipHardGoalCheck;
     private boolean json = true;
 
     public boolean isDryRun() {
@@ -19,6 +20,10 @@ public class RebalanceOptions {
 
     public boolean isVerbose() {
         return verbose;
+    }
+
+    public boolean isSkipHardGoalCheck() {
+        return skipHardGoalCheck;
     }
 
     public List<String> getGoals() {
@@ -32,6 +37,7 @@ public class RebalanceOptions {
     private RebalanceOptions(RebalanceOptionsBuilder builder) {
         this.isDryRun = builder.isDryRun;
         this.verbose = builder.verbose;
+        this.skipHardGoalCheck = builder.skipHardGoalCheck;
         this.goals = builder.goals;
         this.verbose = builder.verbose;
     }
@@ -40,11 +46,13 @@ public class RebalanceOptions {
 
         private boolean isDryRun;
         private boolean verbose;
+        private boolean skipHardGoalCheck;
         private List<String> goals;
 
         public RebalanceOptionsBuilder() {
             isDryRun = true;
             verbose = false;
+            skipHardGoalCheck = false;
             goals = null;
         }
 
@@ -55,6 +63,11 @@ public class RebalanceOptions {
 
         public RebalanceOptionsBuilder withVerboseResponse() {
             this.verbose = true;
+            return this;
+        }
+
+        public RebalanceOptionsBuilder withSkipHardGoalCheck() {
+            this.skipHardGoalCheck = true;
             return this;
         }
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2812,10 +2812,12 @@ Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
 
 [options="header"]
 |====
-|Property        |Description
-|goals    1.2+<.<|A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it.The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.
+|Property                  |Description
+|goals              1.2+<.<|A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it.The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.
 |string array
-|verbose  1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
+|skipHardGoalCheck  1.2+<.<|Whether allow hard goals be skipped in proposal generation. Default is false.
+|boolean
+|verbose            1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
 |boolean
 |====
 

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2813,9 +2813,9 @@ Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
 [options="header"]
 |====
 |Property                  |Description
-|goals              1.2+<.<|A list of goals, ordered by decreasing priority, to use in generating the proposal and executing it.The supported goals are available at https://github.com/linkedin/cruise-control#goals.Providing empty goals means to use all the ones declared in the default.goals cruise control configuration parameter.
+|goals              1.2+<.<|A list of goals, ordered by decreasing priority, to use for generating and executing the rebalance proposal.The supported goals are available at https://github.com/linkedin/cruise-control#goals.If an empty goals list is provided, the goals declared in the default.goals Cruise Control configuration parameter are used.
 |string array
-|skipHardGoalCheck  1.2+<.<|Whether allow hard goals be skipped in proposal generation. Default is false.
+|skipHardGoalCheck  1.2+<.<|Whether to allow hard goals to be skipped in rebalance proposal generation. Default is false.
 |boolean
 |verbose            1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
 |boolean

--- a/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/040-Crd-kafka.yaml
@@ -4861,7 +4861,7 @@ spec:
                     failed.brokers.zk.path,webserver.http., webserver.api.urlprefix,
                     webserver.session.path, webserver.accesslog., two.step., request.reason.required,metric.reporter.sampler.bootstrap.servers,
                     metric.reporter.topic, partition.metric.sample.store.topic, broker.metric.sample.store.topic,capacity.config.file,
-                    self.healing., ssl.'
+                    self.healing., anomaly.detection., ssl.'
                 livenessProbe:
                   type: object
                   properties:

--- a/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkaclusterrebalance.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkaclusterrebalance.yaml
@@ -38,10 +38,14 @@ spec:
               items:
                 type: string
               description: A list of goals, ordered by decreasing priority, to use
-                in generating the proposal and executing it.The supported goals are
-                available at https://github.com/linkedin/cruise-control#goals.Providing
-                empty goals means to use all the ones declared in the default.goals
-                cruise control configuration parameter.
+                for generating and executing the rebalance proposal.The supported
+                goals are available at https://github.com/linkedin/cruise-control#goals.If
+                an empty goals list is provided, the goals declared in the default.goals
+                Cruise Control configuration parameter are used.
+            skipHardGoalCheck:
+              type: boolean
+              description: Whether to allow hard goals to be skipped in rebalance
+                proposal generation. Default is false.
             verbose:
               type: boolean
               description: Enable the verbose mode for the JSON string describing

--- a/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
@@ -37,6 +37,10 @@ spec:
                 available at https://github.com/linkedin/cruise-control#goals.Providing
                 empty goals means to use all the ones declared in the default.goals
                 cruise control configuration parameter.
+            skipHardGoalCheck:
+              type: boolean
+              description: Whether allow hard goals be skipped in proposal generation.
+                Default is false.
             verbose:
               type: boolean
               description: Enable the verbose mode for the JSON string describing

--- a/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
@@ -33,14 +33,14 @@ spec:
               items:
                 type: string
               description: A list of goals, ordered by decreasing priority, to use
-                in generating the proposal and executing it.The supported goals are
-                available at https://github.com/linkedin/cruise-control#goals.Providing
-                empty goals means to use all the ones declared in the default.goals
-                cruise control configuration parameter.
+                for generating and executing the rebalance proposal.The supported
+                goals are available at https://github.com/linkedin/cruise-control#goals.If
+                an empty goals list is provided, the goals declared in the default.goals
+                Cruise Control configuration parameter are used.
             skipHardGoalCheck:
               type: boolean
-              description: Whether allow hard goals be skipped in proposal generation.
-                Default is false.
+              description: Whether to allow hard goals to be skipped in rebalance
+                proposal generation. Default is false.
             verbose:
               type: boolean
               description: Enable the verbose mode for the JSON string describing


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds the `skipHardGoalCheck` on the rebalance resource so that the user can provide a resource without any hard goals in the `goals` section and CC will skip the check (default is false).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

