### PR TITLE
Updated rebalance-operator and client logic for in-progress opt proposal

### DIFF
--- a/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
+++ b/api/src/main/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceSpec.java
@@ -23,7 +23,7 @@ import java.util.Map;
         builderPackage = "io.fabric8.kubernetes.api.builder"
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder({ "goals", "skipHardGoalCheck", "verbose" })
+@JsonPropertyOrder({ "goals", "skipHardGoalCheck" })
 @EqualsAndHashCode
 public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Serializable {
 
@@ -31,7 +31,6 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     private List<String> goals;
     private boolean skipHardGoalCheck;
-    private boolean verbose = false;
 
     private Map<String, Object> additionalProperties = new HashMap<>(0);
 
@@ -54,16 +53,6 @@ public class KafkaClusterRebalanceSpec implements UnknownPropertyPreserving, Ser
 
     public void setSkipHardGoalCheck(boolean skipHardGoalCheck) {
         this.skipHardGoalCheck = skipHardGoalCheck;
-    }
-
-    @Description("Enable the verbose mode for the JSON string describing the optimization result in the related status")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public boolean isVerbose() {
-        return verbose;
-    }
-
-    public void setVerbose(boolean verbose) {
-        this.verbose = verbose;
     }
 
     @Override

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
@@ -12,13 +12,12 @@ import io.vertx.core.Future;
 public interface CruiseControlApi {
 
     String CC_REST_API_ERROR_KEY = "errorMessage";
-    String CC_REST_API_STACKTRACE_KEY = "stackTrace";
+    String CC_REST_API_PROGRESS_KEY = "progress";
     String CC_REST_API_USER_ID_HEADER = "User-Task-ID";
     String CC_REST_API_SUMMARY = "summary";
 
     Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose);
-    Future<Boolean> isProposalReady(String host, int port);
-    Future<CruiseControlResponse> rebalance(String host, int port, RebalanceOptions options);
+    Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskID);
     Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskId);
     Future<CruiseControlResponse> stopExecution(String host, int port);
 

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlRebalanceResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlRebalanceResponse.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly.cruisecontrol;
+
+import io.vertx.core.json.JsonObject;
+
+public class CruiseControlRebalanceResponse extends CruiseControlResponse {
+
+    private boolean notEnoughDataForProposal;
+    private boolean proposalIsStillCalculating;
+
+    CruiseControlRebalanceResponse(String userTaskId, JsonObject json) {
+        super(userTaskId, json);
+        this.notEnoughDataForProposal = false;
+        this.proposalIsStillCalculating = false;
+    }
+
+    public boolean thereIsNotEnoughDataForProposal() {
+        return this.notEnoughDataForProposal;
+    }
+
+    public void setNotEnoughDataForProposal(boolean notEnoughData) {
+        this.notEnoughDataForProposal = notEnoughData;
+    }
+
+    public boolean proposalIsStillCalculating() {
+        return proposalIsStillCalculating;
+    }
+
+    public void setProposalIsStillCalculating(boolean proposalIsStillCalculating) {
+        this.proposalIsStillCalculating = proposalIsStillCalculating;
+    }
+}

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlResponse.java
@@ -10,12 +10,10 @@ public class CruiseControlResponse {
 
     private String userTaskId;
     private JsonObject json;
-    private boolean notEnoughDataForProposal;
 
     CruiseControlResponse(String userTaskId, JsonObject json) {
         this.userTaskId = userTaskId;
         this.json = json;
-        this.notEnoughDataForProposal = false;
     }
 
     public String getUserTaskId() {
@@ -34,12 +32,5 @@ public class CruiseControlResponse {
         return "User Task ID: " + userTaskId + " JSON: " + json.toString();
     }
 
-    public boolean thereIsNotEnoughDataForProposal() {
-        return this.notEnoughDataForProposal;
-    }
-
-    public void setNotEnoughDataForProposal(boolean notEnoughData) {
-        this.notEnoughDataForProposal = notEnoughData;
-    }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlClientTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlClientTest.java
@@ -61,34 +61,6 @@ public class CruiseControlClientTest {
     }
 
     @Test
-    public void testProposalReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-
-        MockCruiseControl.setupCCStateResponse(ccServer);
-
-        CruiseControlApi client = new CruiseControlApiImpl(vertx);
-
-        client.isProposalReady(HOST, PORT).setHandler(
-                context.succeeding(result -> {
-                    context.verify(() -> assertThat(result, is(true)));
-                    context.completeNow();
-                }));
-    }
-
-    @Test
-    public void testProposalNotReady(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
-
-        MockCruiseControl.setupCCStateResponse(ccServer);
-
-        CruiseControlApiImpl client = new CruiseControlApiImpl(vertx);
-
-        client.isProposalReady(HOST, PORT, MockCruiseControl.STATE_PROPOSAL_NOT_READY).setHandler(
-                context.succeeding(result -> {
-                    context.verify(() -> assertThat(result, is(false)));
-                    context.completeNow();
-                }));
-    }
-
-    @Test
     public void testCCRebalance(Vertx vertx, VertxTestContext context) throws IOException, URISyntaxException {
 
         MockCruiseControl.setupCCRebalanceResponse(ccServer);
@@ -97,7 +69,7 @@ public class CruiseControlClientTest {
 
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
-        client.rebalance(HOST, PORT, rbOptions).setHandler(context.succeeding(result -> {
+        client.rebalance(HOST, PORT, rbOptions, null).setHandler(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.REBALANCE_NO_GOALS_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().containsKey("summary"), is(true)));
             context.verify(() -> assertThat(result.getJson().containsKey("goalSummary"), is(true)));
@@ -115,7 +87,7 @@ public class CruiseControlClientTest {
 
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
-        client.rebalance(HOST, PORT, rbOptions).setHandler(context.succeeding(result -> {
+        client.rebalance(HOST, PORT, rbOptions, null).setHandler(context.succeeding(result -> {
             context.verify(() -> assertThat(result.getUserTaskId(), is(MockCruiseControl.REBALANCE_NO_GOALS_VERBOSE_RESPONSE_UTID)));
             context.verify(() -> assertThat(result.getJson().containsKey("summary"), is(true)));
             context.verify(() -> assertThat(result.getJson().containsKey("goalSummary"), is(true)));

--- a/documentation/modules/appendix_crds.adoc
+++ b/documentation/modules/appendix_crds.adoc
@@ -2817,8 +2817,6 @@ Used in: xref:type-KafkaClusterRebalance-{context}[`KafkaClusterRebalance`]
 |string array
 |skipHardGoalCheck  1.2+<.<|Whether to allow hard goals to be skipped in rebalance proposal generation. Default is false.
 |boolean
-|verbose            1.2+<.<|Enable the verbose mode for the JSON string describing the optimization result in the related status.
-|boolean
 |====
 
 [id='type-KafkaClusterRebalanceStatus-{context}']

--- a/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkaclusterrebalance.yaml
+++ b/helm-charts/strimzi-kafka-operator/templates/049-Crd-kafkaclusterrebalance.yaml
@@ -46,10 +46,6 @@ spec:
               type: boolean
               description: Whether to allow hard goals to be skipped in rebalance
                 proposal generation. Default is false.
-            verbose:
-              type: boolean
-              description: Enable the verbose mode for the JSON string describing
-                the optimization result in the related status.
           description: The specification of the Kafka Cluster Rebalance.
         status:
           type: object

--- a/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
+++ b/install/cluster-operator/049-Crd-kafkaclusterrebalance.yaml
@@ -41,10 +41,6 @@ spec:
               type: boolean
               description: Whether to allow hard goals to be skipped in rebalance
                 proposal generation. Default is false.
-            verbose:
-              type: boolean
-              description: Enable the verbose mode for the JSON string describing
-                the optimization result in the related status.
           description: The specification of the Kafka Cluster Rebalance.
         status:
           type: object


### PR DESCRIPTION
This PR deals with the case where a proposal is not ready immediately. I have checked the logic flow and made sure the state machine is not effected. 

There are several issues that I noticed whilst doing this and flagged with `TODO`s in the comments.

I have done a smoke test with this version and all seems to work correctly.