### PR TITLE
Removed "verbose" flag tests

### DIFF
--- a/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
+++ b/api/src/test/java/io/strimzi/api/kafka/model/KafkaClusterRebalanceCrdIT.java
@@ -30,11 +30,6 @@ public class KafkaClusterRebalanceCrdIT extends AbstractCrdIT {
     }
 
     @Test
-    void testKafkaClusterRebalanceWithGoalsVerbose() {
-        createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals-verbose.yaml");
-    }
-
-    @Test
     void testKafkaClusterRebalanceWithGoalsSkipHardGoalCheck() {
         createDelete(KafkaClusterRebalance.class, "KafkaClusterRebalance-with-goals-skip-hard-goal-check.yaml");
     }

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-verbose.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance-with-goals-verbose.yaml
@@ -1,9 +1,0 @@
-apiVersion: kafka.strimzi.io/v1alpha1
-kind: KafkaClusterRebalance
-metadata:
-  name: my-rebalance
-spec:
-  goals:
-    - DiskCapacityGoal
-    - CpuCapacityGoal
-  verbose: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.out.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.out.yaml
@@ -7,4 +7,4 @@ spec:
   goals:
   - "DiskCapacityGoal"
   - "CpuCapacityGoal"
-  verbose: true
+  skipHardGoalCheck: true

--- a/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.yaml
+++ b/api/src/test/resources/io/strimzi/api/kafka/model/KafkaClusterRebalance.yaml
@@ -6,4 +6,4 @@ spec:
   goals:
     - DiskCapacityGoal
     - CpuCapacityGoal
-  verbose: true
+  skipHardGoalCheck: true


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This PR remove `KafkaClusterRebalance` resource tests with "verbose" which was removed from the initial CRD.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

