### PR TITLE
Added logic to handle CC user tasks endpoint bug

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlApi.java
@@ -18,7 +18,7 @@ public interface CruiseControlApi {
 
     Future<CruiseControlResponse> getCruiseControlState(String host, int port, boolean verbose);
     Future<CruiseControlRebalanceResponse> rebalance(String host, int port, RebalanceOptions options, String userTaskID);
-    Future<CruiseControlResponse> getUserTaskStatus(String host, int port, String userTaskId);
+    Future<CruiseControlUserTaskResponse> getUserTaskStatus(String host, int port, String userTaskId);
     Future<CruiseControlResponse> stopExecution(String host, int port);
 
 }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlUserTaskResponse.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/CruiseControlUserTaskResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+package io.strimzi.operator.cluster.operator.assembly.cruisecontrol;
+
+import io.vertx.core.json.JsonObject;
+
+public class CruiseControlUserTaskResponse extends CruiseControlResponse {
+
+    private boolean completedWithError;
+
+    CruiseControlUserTaskResponse(String userTaskId, JsonObject json) {
+        super(userTaskId, json);
+        this.completedWithError = false;
+    }
+
+    public boolean completedWithError() {
+        return completedWithError;
+    }
+
+    public void setCompletedWithError(boolean completedWithError) {
+        this.completedWithError = completedWithError;
+    }
+
+
+}

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/cruisecontrol/MockCruiseControlTest.java
@@ -51,7 +51,7 @@ public class MockCruiseControlTest {
 
         CruiseControlApi client = new CruiseControlApiImpl(vertx);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
+        Future<CruiseControlUserTaskResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
 
         if (pendingCalls > 0) {
             for (int i = 1; i <= pendingCalls; i++) {
@@ -109,7 +109,7 @@ public class MockCruiseControlTest {
 
         MockCruiseControl.setupCCUserTasksResponse(ccServer, pendingCalls1);
 
-        Future<CruiseControlResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
+        Future<CruiseControlUserTaskResponse> statusFuture = client.getUserTaskStatus(HOST, PORT, userTaskID);
 
         for (int i = 1; i <= pendingCalls1; i++) {
             statusFuture = statusFuture.compose(response -> {


### PR DESCRIPTION
Adds handling for a bug in the CC rest api user tasks end point which will throw an error if you ask for the status of a `COMPLETED_WITH_ERROR` task when `fetch_completed_tasks=true`.
