### PR TITLE
Fixed infinite pending proposal on cruise control not enough data error

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControl.java
@@ -60,7 +60,6 @@ import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUIS
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_ANOMALY_DETECTION_GOALS;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY;
-import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createConfigMapVolume;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createSecretVolume;
 import static io.strimzi.operator.cluster.model.VolumeUtils.createVolumeMount;
@@ -235,7 +234,7 @@ public class CruiseControl extends AbstractModel {
 
     public static CruiseControl updateConfiguration(CruiseControlSpec spec, CruiseControl cruiseControl) {
         CruiseControlConfiguration userConfiguration = new CruiseControlConfiguration(spec.getConfig().entrySet());
-        for (Map.Entry<String, String> defaultEntry : CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP.entrySet()) {
+        for (Map.Entry<String, String> defaultEntry : CruiseControlConfiguration.getCruiseControlDefaultPropertiesMap().entrySet()) {
             if (userConfiguration.getConfigOption(defaultEntry.getKey()) == null) {
                 userConfiguration.setConfigOption(defaultEntry.getKey(), defaultEntry.getValue());
             }

--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/model/CruiseControlConfiguration.java
@@ -50,7 +50,7 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
    /*
     * Map containing default values for required configuration properties
     */
-    public static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
+    private static final Map<String, String> CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
 
     private static final List<String> FORBIDDEN_OPTIONS;
     private static final List<String> EXCEPTIONS;
@@ -81,5 +81,9 @@ public class CruiseControlConfiguration extends AbstractConfiguration {
 
     private CruiseControlConfiguration(String configuration, List<String> forbiddenOptions) {
         super(configuration, forbiddenOptions);
+    }
+
+    public static Map<String, String> getCruiseControlDefaultPropertiesMap() {
+        return CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
     }
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/model/CruiseControlTest.java
@@ -55,7 +55,6 @@ import static io.strimzi.operator.cluster.model.CruiseControl.ENV_VAR_BROKER_INB
 import static io.strimzi.operator.cluster.model.CruiseControl.ENV_VAR_BROKER_OUTBOUND_NETWORK_KIB_PER_SECOND_CAPACITY;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_ANOMALY_DETECTION_CONFIG_KEY;
 import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_GOALS_CONFIG_KEY;
-import static io.strimzi.operator.cluster.model.CruiseControlConfiguration.CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP;
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_CPU_UTILIZATION_CAPACITY;
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_DISK_MIB_CAPACITY;
 import static io.strimzi.operator.cluster.model.cruisecontrol.Capacity.DEFAULT_BROKER_INBOUND_NETWORK_KIB_PER_SECOND_CAPACITY;
@@ -87,7 +86,7 @@ public class CruiseControlTest {
     private final Map<String, Object> zooConfig = singletonMap("foo", "bar");
 
     CruiseControlConfiguration configuration = new CruiseControlConfiguration(new HashMap<String, Object>() {{
-            putAll(CRUISE_CONTROL_DEFAULT_PROPERTIES_MAP);
+            putAll(CruiseControlConfiguration.getCruiseControlDefaultPropertiesMap());
             put("num.partition.metrics.windows", "2");
         }}.entrySet()
     );


### PR DESCRIPTION
### Type of change

- Bugfix
- Refactoring

### Description

This PR reverts back a change made on `CruiseControlConfiguration` about exposing the default properties map due to spotbugs.
It also fix the endless pending proposal state when there are not enough data (the session-id has not to be set in that case because it's actually a cruise control error).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

