### PR TITLE
Fixed the testNewRebalance test

### DIFF
--- a/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
+++ b/cluster-operator/src/main/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperator.java
@@ -733,7 +733,7 @@ public class KafkaRebalanceAssemblyOperator
         }
     }
 
-    private Future<Void> reconcileRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
+    /* test */ Future<Void> reconcileRebalance(Reconciliation reconciliation, KafkaRebalance kafkaRebalance) {
         if (kafkaRebalance == null) {
             log.info("{}: Rebalance resource deleted", reconciliation);
             return Future.succeededFuture();

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -4,9 +4,8 @@
  */
 package io.strimzi.operator.cluster.operator.assembly;
 
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.KafkaList;
 import io.strimzi.api.kafka.KafkaRebalanceList;
 import io.strimzi.api.kafka.model.CruiseControlSpec;
@@ -20,7 +19,6 @@ import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpec;
 import io.strimzi.api.kafka.model.KafkaRebalanceSpecBuilder;
-import io.strimzi.api.kafka.model.status.Condition;
 import io.strimzi.operator.KubernetesVersion;
 import io.strimzi.operator.PlatformFeaturesAvailability;
 import io.strimzi.operator.cluster.KafkaVersionTestUtils;
@@ -31,9 +29,9 @@ import io.strimzi.operator.cluster.operator.resource.ResourceOperatorSupplier;
 import io.strimzi.operator.common.Reconciliation;
 import io.strimzi.operator.common.model.Labels;
 import io.strimzi.operator.common.operator.resource.CrdOperator;
+import io.strimzi.test.mockkube.MockKube;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.junit5.Checkpoint;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import org.apache.logging.log4j.LogManager;
@@ -47,19 +45,21 @@ import org.mockserver.integration.ClientAndServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collections;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(VertxExtension.class)
 public class KafkaRebalanceAssemblyOperatorTest {
 
     private static final String HOST = "localhost";
+    private static final String RESOURCE_NAME = "my-rebalance";
     private static final String CLUSTER_NAMESPACE = "cruise-control-namespace";
-    private static final String CLUSTER_NAME = "cruise-control-test-cluster";
+    private static final String CLUSTER_NAME = "kafka-cruise-control-test-cluster";
 
     private final KubernetesVersion kubernetesVersion = KubernetesVersion.V1_11;
 
@@ -67,8 +67,6 @@ public class KafkaRebalanceAssemblyOperatorTest {
 
     private static ClientAndServer ccServer;
 
-    private final String namespace = "test";
-    private final String cluster = "foo";
     private final int replicas = 1;
     private final String image = "my-kafka-image";
     private final int healthDelay = 120;
@@ -82,7 +80,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
             .build();
 
     private final Kafka kafka =
-            new KafkaBuilder(ResourceUtils.createKafkaCluster(namespace, cluster, replicas, image, healthDelay, healthTimeout))
+            new KafkaBuilder(ResourceUtils.createKafkaCluster(CLUSTER_NAMESPACE, CLUSTER_NAME, replicas, image, healthDelay, healthTimeout))
                     .editSpec()
                         .editKafka()
                             .withVersion(version)
@@ -113,23 +111,20 @@ public class KafkaRebalanceAssemblyOperatorTest {
         MockCruiseControl.setupCCRebalanceResponse(ccServer);
         MockCruiseControl.setupCCUserTasksResponse(ccServer, 0);
 
-        Map<String, String> labels = new HashMap<>();
-        labels.put(Labels.STRIMZI_CLUSTER_LABEL, "my-test-cluster");
-        ObjectMeta meta = new ObjectMetaBuilder().withLabels(labels).withName(CLUSTER_NAME).withNamespace(CLUSTER_NAMESPACE).build();
+        KubernetesClient client = new MockKube()
+                .withCustomResourceDefinition(Crds.kafkaRebalance(), KafkaRebalance.class, KafkaRebalanceList.class, DoneableKafkaRebalance.class)
+                .end()
+                .build();
 
         KafkaRebalanceSpec rebalanceSpec = new KafkaRebalanceSpecBuilder().build();
 
-        Condition newRebalanceCondition = new Condition();
-        newRebalanceCondition.setType(String.valueOf(KafkaRebalanceAssemblyOperator.State.New));
-
-        KafkaRebalanceBuilder kcrBuilder = new KafkaRebalanceBuilder();
-
-        KafkaRebalance kcRebalance = kcrBuilder
-                .withMetadata(meta)
+        KafkaRebalance kcRebalance = new KafkaRebalanceBuilder()
+                .withNewMetadata()
+                    .withNamespace(CLUSTER_NAMESPACE)
+                    .withName(RESOURCE_NAME)
+                    .withLabels(Collections.singletonMap(Labels.STRIMZI_CLUSTER_LABEL, CLUSTER_NAME))
+                .endMetadata()
                 .withSpec(rebalanceSpec)
-                .withNewStatus()
-                    .withConditions(newRebalanceCondition)
-                .endStatus()
                 .build();
 
         ResourceOperatorSupplier supplier = ResourceUtils.supplierWithMocks(true);
@@ -146,22 +141,40 @@ public class KafkaRebalanceAssemblyOperatorTest {
                 KafkaList,
                 DoneableKafka> mockKafkaOps = supplier.kafkaOperator;
 
-        when(mockKafkaOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kafka));
-        when(mockRebalanceOps.get(CLUSTER_NAMESPACE, CLUSTER_NAME)).thenReturn(kcRebalance);
-        when(mockRebalanceOps.getAsync(anyString(), anyString())).thenReturn(Future.succeededFuture(kcRebalance));
-        when(mockRebalanceOps.updateStatusAsync(any(KafkaRebalance.class))).thenReturn(Future.succeededFuture(kcRebalance));
+        Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).create(kcRebalance);
 
-        Checkpoint async = context.checkpoint();
-        kcrao.createOrUpdate(
-                new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, CLUSTER_NAMESPACE, CLUSTER_NAME),
-                kcRebalance).setHandler(createResult -> {
-                    if (createResult.succeeded()) {
-                        context.completeNow();
-                    } else {
-                        context.failNow(createResult.cause());
-                    }
-                    async.flag();
-                });
+        when(mockKafkaOps.getAsync(CLUSTER_NAMESPACE, CLUSTER_NAME)).thenReturn(Future.succeededFuture(kafka));
+        when(mockRebalanceOps.getAsync(CLUSTER_NAMESPACE, RESOURCE_NAME)).thenAnswer(invocation -> {
+            try {
+                return Future.succeededFuture(Crds.kafkaRebalanceOperation(client)
+                        .inNamespace(CLUSTER_NAMESPACE)
+                        .withName(RESOURCE_NAME)
+                        .get());
+            } catch (Exception e) {
+                return Future.failedFuture(e);
+            }
+        });
+        when(mockRebalanceOps.updateStatusAsync(any(KafkaRebalance.class))).thenAnswer(invocation -> {
+            try {
+                return Future.succeededFuture(Crds.kafkaRebalanceOperation(client)
+                        .inNamespace(CLUSTER_NAMESPACE)
+                        .withName(RESOURCE_NAME)
+                        .patch(invocation.getArgument(0)));
+            } catch (Exception e) {
+                return Future.failedFuture(e);
+            }
+        });
+
+        kcrao.reconcileRebalance(
+                new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
+                kcRebalance).setHandler(context.succeeding(v -> context.verify(() -> {
+                    KafkaRebalance kr = Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
+                    assertThat(kr, notNullValue());
+                    assertThat(kr.getStatus(), notNullValue());
+                    assertThat(kr.getStatus().getConditions(), notNullValue());
+                    assertThat(kr.getStatus().getConditions().get(0).getType(), is(KafkaRebalanceAssemblyOperator.State.ProposalReady.toString()));
+                    context.completeNow();
+                })));
     }
 
 }

--- a/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
+++ b/cluster-operator/src/test/java/io/strimzi/operator/cluster/operator/assembly/KafkaRebalanceAssemblyOperatorTest.java
@@ -13,7 +13,6 @@ import io.strimzi.api.kafka.model.CruiseControlSpecBuilder;
 import io.strimzi.api.kafka.model.DoneableKafka;
 import io.strimzi.api.kafka.model.DoneableKafkaRebalance;
 import io.strimzi.api.kafka.model.Kafka;
-import io.strimzi.api.kafka.model.KafkaBridge;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.KafkaRebalance;
 import io.strimzi.api.kafka.model.KafkaRebalanceBuilder;
@@ -166,7 +165,7 @@ public class KafkaRebalanceAssemblyOperatorTest {
         });
 
         kcrao.reconcileRebalance(
-                new Reconciliation("test-trigger", KafkaBridge.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
+                new Reconciliation("test-trigger", KafkaRebalance.RESOURCE_KIND, CLUSTER_NAMESPACE, RESOURCE_NAME),
                 kcRebalance).setHandler(context.succeeding(v -> context.verify(() -> {
                     KafkaRebalance kr = Crds.kafkaRebalanceOperation(client).inNamespace(CLUSTER_NAMESPACE).withName(RESOURCE_NAME).get();
                     assertThat(kr, notNullValue());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This PR executes the New resource base test in the right way using a mocked Kubernetes client and following the operator reconciliation path.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Update/write design documentation in `./design`
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Check RBAC rights for Kubernetes / OpenShift roles
- [ ] Try your changes from Pod inside your Kubernetes and OpenShift cluster, not just locally
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md

